### PR TITLE
"initialValue" initialization moved to the beginning

### DIFF
--- a/lib/change.js
+++ b/lib/change.js
@@ -26,9 +26,9 @@ module.exports = function reactTriggerChange(node) {
   };
   var nodeName = node.nodeName.toLowerCase();
   var type = node.type;
+  var initialValue = node.value;
   var event;
   var descriptor;
-  var initialValue;
   var initialChecked;
   var initialCheckedRadio;
 
@@ -117,7 +117,6 @@ module.exports = function reactTriggerChange(node) {
     if (type === 'range') {
       changeRangeValue(node);
     } else {
-      initialValue = node.value;
       node.value = initialValue + '#';
       deletePropertySafe(node, 'value');
       node.value = initialValue;


### PR DESCRIPTION
In some situation, events (such as `"focus"`), fired before the `initialValue` is used, can have unexpected side-effects on `node.value`. (e.g. `onFocus` handler may clear the input field). Moving the initialization to the top protects the original (intended) value. 