### PR TITLE
Save initial value before focus

### DIFF
--- a/lib/change.js
+++ b/lib/change.js
@@ -99,6 +99,11 @@ module.exports = function reactTriggerChange(node) {
     // Property doesn't exist in React <16, descriptor is undefined.
     descriptor = Object.getOwnPropertyDescriptor(node, 'value');
 
+    // react-select clears input on focus
+    if (type !== 'range') {
+      initialValue = node.value;
+    }
+
     // React 0.14: IE9
     // React 15: IE9-IE11
     // React 16: IE9
@@ -117,7 +122,6 @@ module.exports = function reactTriggerChange(node) {
     if (type === 'range') {
       changeRangeValue(node);
     } else {
-      initialValue = node.value;
       node.value = initialValue + '#';
       deletePropertySafe(node, 'value');
       node.value = initialValue;


### PR DESCRIPTION
Saving node initial value to variable before focus, so components that clear input on focus work